### PR TITLE
Fix #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack -p --progress --profile --colors",
     "clean": "rimraf dist",
-    "lint": "npm run lint:css && npm run lint:js",
+    "lint": "npm run lint:css; npm run lint:js",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:js": "eslint src/**",
     "start": "nodemon dist/server",


### PR DESCRIPTION
Edit lint NPM script so it will lint both CSS and JS no matter what the exit code is.

In practice, if there are errors detected when linting the CSS it will not lint JS.
